### PR TITLE
feat: add highlighter element

### DIFF
--- a/.kick.yml
+++ b/.kick.yml
@@ -1,4 +1,4 @@
-# Kickstart container config file - see https://gitub.com/infracamp/kickstart
+# Kickstart container config file - see https://github.com/infracamp/kickstart
 # Run ./kickstart.sh to start a development-container for this project
 version: 1
 from: "ghcr.io/nfra-project/kickstart-flavor-php:unstable"

--- a/index.doc.ts
+++ b/index.doc.ts
@@ -1,6 +1,4 @@
-
-
-
+import "./src/element-highlighter/doc";
 import "./src/switch-pane/doc";
 import "./src/lead-button/doc";
 import "./src/infiniscroll/doc";

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-
+export * from './src/element-highlighter/nxa-element-highlighter';
 export * from './src/form/nxa-form-group';
 export * from './src/form/nxa-form-input';
 export * from './src/form/nxa-form-textarea';

--- a/src/element-highlighter/doc.ts
+++ b/src/element-highlighter/doc.ts
@@ -9,7 +9,7 @@ registerComponent({
             title: "Highlight a static element",
             description: `
 <p>This test shows a grey div, which is the target for highlighting.</p>
-<p>The highlighter is initially hidden - use the <code>Show</code> and <code>Hide</code> buttons.</p>
+<p>The highlighter is initially hidden; use the <code>Show</code> and <code>Hide</code> buttons/methods or the <code>initiallyShown</code> attribute.</p>
 <p>Properties like border width and color can be changed via attributes.</p>
 <p>Use the browser dev tools to resize/style the target element and see how the highlighter adjusts.</p>
 `,
@@ -21,28 +21,67 @@ registerComponent({
     style="background: grey; width: 100px; height: 100px"
 ></div>
 <nxa-element-highlighter
+    id="element-highlighter-1"
     selector="#element-highlighter-target-element"
 ></nxa-element-highlighter>
 
 <fieldset style="margin-top: 20px">
     <legend>Demo Controls</legend>
 
-    <button onclick="document.querySelector('nxa-element-highlighter').show()">Show</button>
-    <button onclick="document.querySelector('nxa-element-highlighter').hide()">Hide</button>
+    <button onclick="document.getElementById('element-highlighter-1').show()">Show</button>
+    <button onclick="document.getElementById('element-highlighter-1').hide()">Hide</button>
 
     <label for="el-highlight-demo-1-border-with-ctrl">Border Width</label>
-    <select id="el-highlight-demo-1-border-with-ctrl" onchange="document.querySelector('nxa-element-highlighter').borderWidth = this.value">
+    <select id="el-highlight-demo-1-border-with-ctrl" onchange="document.getElementById('element-highlighter-1').borderWidth = this.value">
         <option value="1">1</option>
         <option value="2" selected>2</option>
         <option value="3">3</option>
     </select>
 
     <label for="el-highlight-demo-1-border-color-ctrl">Border Color</label>
-    <select id="el-highlight-demo-1-border-color-ctrl" onchange="document.querySelector('nxa-element-highlighter').borderColor = this.value">
+    <select id="el-highlight-demo-1-border-color-ctrl" onchange="document.getElementById('element-highlighter-1').borderColor = this.value">
         <option value="red" selected>red</option>
         <option value="green">green</option>
         <option value="blue">blue</option>
     </select>
+</fieldset>
+            `
+        },
+        {
+            title: "Highlighter with buttons",
+            description: `
+<p>This example shows a highlighter with buttons. Buttons must be positioned with the <code>slot</code> attribute, otherwise they will not be rendered. The possible slot positions are:</p>
+<ul>
+    <li><code>top-left</code></li>
+    <li><code>top-right</code></li>
+    <li><code>bottom-left</code></li>
+    <li><code>bottom-right</code></li>
+</ul>
+            `,
+            lang: "html",
+            code: `
+<div
+    id="element-highlighter-target-element-2"
+    style="background: lightseagreen; width: 500px; height: 150px"
+></div>
+<nxa-element-highlighter
+    id="element-highlighter-2"
+    selector="#element-highlighter-target-element-2"
+    initiallyShown
+>
+    <button slot="top-left" onclick="alert('Top Left Action')">Top Left Action</button>
+    <button slot="top-right" onclick="alert('Top Right Action')">Top Right Action</button>
+    <button slot="bottom-left" onclick="alert('Bottom Left Action')">Bottom Left Action</button>
+    <button slot="bottom-right" onclick="alert('Bottom Right Action')">Bottom Right Action</button>
+
+    <button onclick="alert('Invalid Action')">Invalid Action</button>
+</nxa-element-highlighter>
+
+<fieldset style="margin-top: 20px">
+    <legend>Demo Controls</legend>
+
+    <button onclick="document.getElementById('element-highlighter-2').show()">Show</button>
+    <button onclick="document.getElementById('element-highlighter-2').hide()">Hide</button>
 </fieldset>
             `
         }

--- a/src/element-highlighter/doc.ts
+++ b/src/element-highlighter/doc.ts
@@ -7,7 +7,12 @@ registerComponent({
     examples: [
         {
             title: "Highlight a static element",
-            description: "This test shows a grey div, which is the target for highlighting. The highlighter is initially hidden.",
+            description: `
+<p>This test shows a grey div, which is the target for highlighting.</p>
+<p>The highlighter is initially hidden - use the <code>Show</code> and <code>Hide</code> buttons.</p>
+<p>Properties like border width and color can be changed via attributes.</p>
+<p>Use the browser dev tools to resize/style the target element and see how the highlighter adjusts.</p>
+`,
             lang: "html",
             // language=html
             code: `

--- a/src/element-highlighter/doc.ts
+++ b/src/element-highlighter/doc.ts
@@ -84,6 +84,26 @@ registerComponent({
     <button onclick="document.getElementById('element-highlighter-2').hide()">Hide</button>
 </fieldset>
             `
+        },
+        {
+            title: "Highlighter that is shown on hover",
+            description: `
+<p>This example shows a highlighter that is shown when the user hovers it. This is controlled by the <code>showOnHover</code> attribute.</p>
+            `,
+            lang: "html",
+            code: `
+<div
+    id="element-highlighter-target-element-3"
+    style="background: lightseagreen; width: 500px; height: 150px"
+></div>
+<nxa-element-highlighter
+    id="element-highlighter-3"
+    selector="#element-highlighter-target-element-3"
+    showOnHover
+>
+    <button slot="top-left" onclick="alert('Top Left Action')">Action revealed by hover!</button>
+</nxa-element-highlighter>
+            `
         }
     ]
 })

--- a/src/element-highlighter/doc.ts
+++ b/src/element-highlighter/doc.ts
@@ -18,7 +18,7 @@ registerComponent({
             code: `
 <div
     id="element-highlighter-target-element"
-    style="background: grey; width: 100px; height: 100px"
+    style="background: grey; width: 50%; height: 100px"
 ></div>
 <nxa-element-highlighter
     id="element-highlighter-1"
@@ -94,7 +94,7 @@ registerComponent({
             code: `
 <div
     id="element-highlighter-target-element-3"
-    style="background: lightseagreen; width: 500px; height: 150px"
+    style="background: lightseagreen; width: 50%; height: 150px"
 ></div>
 <nxa-element-highlighter
     id="element-highlighter-3"

--- a/src/element-highlighter/doc.ts
+++ b/src/element-highlighter/doc.ts
@@ -1,0 +1,45 @@
+import {registerComponent} from "@nextrap/doc-visualizer";
+
+registerComponent({
+    package: "element-highlighter",
+    description: "Element Highlighter",
+    title: "NxaElementHighlighter",
+    examples: [
+        {
+            title: "Highlight a static element",
+            description: "This test shows a grey div, which is the target for highlighting. The highlighter is initially hidden.",
+            lang: "html",
+            // language=html
+            code: `
+<div
+    id="element-highlighter-target-element"
+    style="background: grey; width: 100px; height: 100px"
+></div>
+<nxa-element-highlighter
+    selector="#element-highlighter-target-element"
+></nxa-element-highlighter>
+
+<fieldset style="margin-top: 20px">
+    <legend>Demo Controls</legend>
+
+    <button onclick="document.querySelector('nxa-element-highlighter').show()">Show</button>
+    <button onclick="document.querySelector('nxa-element-highlighter').hide()">Hide</button>
+
+    <label for="el-highlight-demo-1-border-with-ctrl">Border Width</label>
+    <select id="el-highlight-demo-1-border-with-ctrl" onchange="document.querySelector('nxa-element-highlighter').borderWidth = this.value">
+        <option value="1">1</option>
+        <option value="2" selected>2</option>
+        <option value="3">3</option>
+    </select>
+
+    <label for="el-highlight-demo-1-border-color-ctrl">Border Color</label>
+    <select id="el-highlight-demo-1-border-color-ctrl" onchange="document.querySelector('nxa-element-highlighter').borderColor = this.value">
+        <option value="red" selected>red</option>
+        <option value="green">green</option>
+        <option value="blue">blue</option>
+    </select>
+</fieldset>
+            `
+        }
+    ]
+})

--- a/src/element-highlighter/nxa-element-highlighter.ts
+++ b/src/element-highlighter/nxa-element-highlighter.ts
@@ -13,6 +13,9 @@ export class NxaElementHighlighter extends LitElement {
     @state()
     private isHidden = true
 
+    @property({ type: Boolean })
+    initiallyShown = false
+
     @property({ type: String })
     selector = '';
 
@@ -41,18 +44,22 @@ export class NxaElementHighlighter extends LitElement {
             this.error = `selector "${this.selector}" not found`;
         }
 
-        window.addEventListener('resize', () => this.requestUpdate);
-        window.addEventListener('scroll', () => this.requestUpdate);
+        window.addEventListener('resize', () => this.requestUpdate());
+        window.addEventListener('scroll', () => this.requestUpdate());
 
         this.resizeObserver.observe(this.targetElement);
         this.mutationObserver.observe(this.targetElement, { attributes: true, attributeFilter: ['style'] });
+
+        if (this.initiallyShown) {
+            this.show();
+        }
     }
 
     disconnectedCallback() {
         super.disconnectedCallback();
 
-        window.removeEventListener('resize', () => this.requestUpdate);
-        window.removeEventListener('scroll', () => this.requestUpdate);
+        window.removeEventListener('resize', () => this.requestUpdate());
+        window.removeEventListener('scroll', () => this.requestUpdate());
 
         this.resizeObserver.disconnect();
         this.mutationObserver.disconnect();
@@ -78,6 +85,33 @@ export class NxaElementHighlighter extends LitElement {
         div.style.height = `${rect.height}px`;
         div.style.border = `${borderWidth}px solid ${this.borderColor}`;
 
+        const topLeftArea = this.createPositionArea('top-left');
+        div.appendChild(topLeftArea);
+
+        const topRightArea = this.createPositionArea('top-right');
+        div.appendChild(topRightArea);
+
+        const bottomLeftArea = this.createPositionArea('bottom-left');
+        div.appendChild(bottomLeftArea);
+
+        const bottomRightArea = this.createPositionArea('bottom-right');
+        div.appendChild(bottomRightArea);
+
         return html`${div}`;
+    }
+
+    private createPositionArea(position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'): HTMLDivElement {
+        const area = document.createElement('div');
+        area.style.position = 'absolute';
+        area.style.top = position.startsWith('top') ? '0' : 'auto';
+        area.style.left = position.endsWith('left') ? '0' : 'auto';
+        area.style.right = position.endsWith('right') ? '0' : 'auto';
+        area.style.bottom = position.startsWith('bottom') ? '0' : 'auto';
+
+        const slot = document.createElement('slot');
+        slot.name = position;
+        area.appendChild(slot);
+
+        return area;
     }
 }

--- a/src/element-highlighter/nxa-element-highlighter.ts
+++ b/src/element-highlighter/nxa-element-highlighter.ts
@@ -4,7 +4,8 @@ import { customElement, property, state } from 'lit/decorators.js';
 @customElement('nxa-element-highlighter')
 export class NxaElementHighlighter extends LitElement {
 
-    private resizeObserver = new ResizeObserver(() => this.requestUpdate());
+    private readonly resizeObserver = new ResizeObserver(() => this.requestUpdate());
+    private readonly mutationObserver = new MutationObserver(() => this.requestUpdate());
 
     @state()
     private _isHidden = true
@@ -46,6 +47,7 @@ export class NxaElementHighlighter extends LitElement {
         window.addEventListener('scroll', () => this.requestUpdate);
 
         this.resizeObserver.observe(this.#targetElement);
+        this.mutationObserver.observe(this.#targetElement, { attributes: true, attributeFilter: ['style'] });
     }
 
     disconnectedCallback() {
@@ -55,6 +57,7 @@ export class NxaElementHighlighter extends LitElement {
         window.removeEventListener('scroll', () => this.requestUpdate);
 
         this.resizeObserver.disconnect();
+        this.mutationObserver.disconnect();
     }
 
     render() {

--- a/src/element-highlighter/nxa-element-highlighter.ts
+++ b/src/element-highlighter/nxa-element-highlighter.ts
@@ -53,7 +53,7 @@ export class NxaElementHighlighter extends LitElement {
         window.addEventListener('scroll', () => this.requestUpdate());
 
         this.resizeObserver.observe(this.targetElement);
-        this.mutationObserver.observe(this.targetElement, { attributes: true, attributeFilter: ['style'] });
+        this.mutationObserver.observe(this.targetElement, { attributeFilter: ['style'] });
 
         if (this.initiallyShown) {
             this.show();
@@ -71,13 +71,13 @@ export class NxaElementHighlighter extends LitElement {
         window.removeEventListener('resize', () => this.requestUpdate());
         window.removeEventListener('scroll', () => this.requestUpdate());
 
+        this.resizeObserver.disconnect();
+        this.mutationObserver.disconnect();
+
         if (this.showOnHover) {
             this.targetElement.removeEventListener('mouseenter', () => this.show());
             this.removeEventListener('mouseleave', () => this.hide());
         }
-
-        this.resizeObserver.disconnect();
-        this.mutationObserver.disconnect();
     }
 
     render() {

--- a/src/element-highlighter/nxa-element-highlighter.ts
+++ b/src/element-highlighter/nxa-element-highlighter.ts
@@ -4,11 +4,14 @@ import { customElement, property, state } from 'lit/decorators.js';
 @customElement('nxa-element-highlighter')
 export class NxaElementHighlighter extends LitElement {
 
+    private error?: string;
+    private targetElement?: HTMLElement;
+
     private readonly resizeObserver = new ResizeObserver(() => this.requestUpdate());
     private readonly mutationObserver = new MutationObserver(() => this.requestUpdate());
 
     @state()
-    private _isHidden = true
+    private isHidden = true
 
     @property({ type: String })
     selector = '';
@@ -22,32 +25,27 @@ export class NxaElementHighlighter extends LitElement {
     @property({ type: String })
     borderColor = 'red';
 
-    #error?: string;
-
-    get #targetElement(): HTMLElement {
-        return document.querySelector(this.selector);
-    }
-
     show() {
-        this._isHidden = false;
+        this.isHidden = false;
     }
 
     hide() {
-        this._isHidden = true;
+        this.isHidden = true;
     }
 
     connectedCallback() {
         super.connectedCallback();
 
-        if (!this.#targetElement) {
-            this.#error = `selector "${this.selector}" not found`;
+        this.targetElement = document.querySelector(this.selector);
+        if (!this.targetElement) {
+            this.error = `selector "${this.selector}" not found`;
         }
 
         window.addEventListener('resize', () => this.requestUpdate);
         window.addEventListener('scroll', () => this.requestUpdate);
 
-        this.resizeObserver.observe(this.#targetElement);
-        this.mutationObserver.observe(this.#targetElement, { attributes: true, attributeFilter: ['style'] });
+        this.resizeObserver.observe(this.targetElement);
+        this.mutationObserver.observe(this.targetElement, { attributes: true, attributeFilter: ['style'] });
     }
 
     disconnectedCallback() {
@@ -61,18 +59,17 @@ export class NxaElementHighlighter extends LitElement {
     }
 
     render() {
-        if (this._isHidden) {
+        if (this.isHidden) {
             return html``;
         }
-        if (this.#error) {
-            return html`<code style="color: red">${this.localName}: ${this.#error}</code>`;
+        if (this.error) {
+            return html`<code style="color: red">${this.localName}: ${this.error}</code>`;
         }
-        const borderWidth = Math.max(this.borderWidth, 0);
-
-        const target = this.#targetElement;
-        const rect = target.getBoundingClientRect();
 
         const div = document.createElement('div');
+        const rect = this.targetElement.getBoundingClientRect();
+        const borderWidth = Math.max(this.borderWidth, 0);
+
         div.style.position = 'fixed';
         div.style.zIndex = this.zIndex;
         div.style.top = `${rect.top - borderWidth}px`;

--- a/src/element-highlighter/nxa-element-highlighter.ts
+++ b/src/element-highlighter/nxa-element-highlighter.ts
@@ -4,6 +4,8 @@ import { customElement, property, state } from 'lit/decorators.js';
 @customElement('nxa-element-highlighter')
 export class NxaElementHighlighter extends LitElement {
 
+    private resizeObserver = new ResizeObserver(() => this.requestUpdate());
+
     @state()
     private _isHidden = true
 
@@ -36,13 +38,23 @@ export class NxaElementHighlighter extends LitElement {
     connectedCallback() {
         super.connectedCallback();
 
-
         if (!this.#targetElement) {
             this.#error = `selector "${this.selector}" not found`;
         }
 
-        window.addEventListener('resize', () => this.requestUpdate());
-        window.addEventListener('scroll', () => this.requestUpdate());
+        window.addEventListener('resize', () => this.requestUpdate);
+        window.addEventListener('scroll', () => this.requestUpdate);
+
+        this.resizeObserver.observe(this.#targetElement);
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+
+        window.removeEventListener('resize', () => this.requestUpdate);
+        window.removeEventListener('scroll', () => this.requestUpdate);
+
+        this.resizeObserver.disconnect();
     }
 
     render() {
@@ -52,7 +64,7 @@ export class NxaElementHighlighter extends LitElement {
         if (this.#error) {
             return html`<code style="color: red">${this.localName}: ${this.#error}</code>`;
         }
-        const borderWith = Math.max(this.borderWidth, 0);
+        const borderWidth = Math.max(this.borderWidth, 0);
 
         const target = this.#targetElement;
         const rect = target.getBoundingClientRect();
@@ -60,11 +72,11 @@ export class NxaElementHighlighter extends LitElement {
         const div = document.createElement('div');
         div.style.position = 'fixed';
         div.style.zIndex = this.zIndex;
-        div.style.top = `${rect.top - borderWith}px`;
-        div.style.left = `${rect.left - borderWith}px`;
+        div.style.top = `${rect.top - borderWidth}px`;
+        div.style.left = `${rect.left - borderWidth}px`;
         div.style.width = `${rect.width}px`;
         div.style.height = `${rect.height}px`;
-        div.style.border = `${borderWith}px solid ${this.borderColor}`;
+        div.style.border = `${borderWidth}px solid ${this.borderColor}`;
 
         return html`${div}`;
     }

--- a/src/element-highlighter/nxa-element-highlighter.ts
+++ b/src/element-highlighter/nxa-element-highlighter.ts
@@ -1,0 +1,71 @@
+import { html, LitElement } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+@customElement('nxa-element-highlighter')
+export class NxaElementHighlighter extends LitElement {
+
+    @state()
+    private _isHidden = true
+
+    @property({ type: String })
+    selector = '';
+
+    @property({ type: String })
+    zIndex = '10';
+
+    @property({ type: Number })
+    borderWidth = 2;
+
+    @property({ type: String })
+    borderColor = 'red';
+
+    #error?: string;
+
+    get #targetElement(): HTMLElement {
+        return document.querySelector(this.selector);
+    }
+
+    show() {
+        this._isHidden = false;
+    }
+
+    hide() {
+        this._isHidden = true;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+
+
+        if (!this.#targetElement) {
+            this.#error = `selector "${this.selector}" not found`;
+        }
+
+        window.addEventListener('resize', () => this.requestUpdate());
+        window.addEventListener('scroll', () => this.requestUpdate());
+    }
+
+    render() {
+        if (this._isHidden) {
+            return html``;
+        }
+        if (this.#error) {
+            return html`<code style="color: red">${this.localName}: ${this.#error}</code>`;
+        }
+        const borderWith = Math.max(this.borderWidth, 0);
+
+        const target = this.#targetElement;
+        const rect = target.getBoundingClientRect();
+
+        const div = document.createElement('div');
+        div.style.position = 'fixed';
+        div.style.zIndex = this.zIndex;
+        div.style.top = `${rect.top - borderWith}px`;
+        div.style.left = `${rect.left - borderWith}px`;
+        div.style.width = `${rect.width}px`;
+        div.style.height = `${rect.height}px`;
+        div.style.border = `${borderWith}px solid ${this.borderColor}`;
+
+        return html`${div}`;
+    }
+}

--- a/src/element-highlighter/nxa-element-highlighter.ts
+++ b/src/element-highlighter/nxa-element-highlighter.ts
@@ -16,6 +16,9 @@ export class NxaElementHighlighter extends LitElement {
     @property({ type: Boolean })
     initiallyShown = false
 
+    @property({ type: Boolean })
+    showOnHover = false;
+
     @property({ type: String })
     selector = '';
 
@@ -44,6 +47,8 @@ export class NxaElementHighlighter extends LitElement {
             this.error = `selector "${this.selector}" not found`;
         }
 
+        this.validateInputs();
+
         window.addEventListener('resize', () => this.requestUpdate());
         window.addEventListener('scroll', () => this.requestUpdate());
 
@@ -53,6 +58,11 @@ export class NxaElementHighlighter extends LitElement {
         if (this.initiallyShown) {
             this.show();
         }
+
+        if (this.showOnHover) {
+            this.targetElement.addEventListener('mouseenter', () => this.show());
+            this.addEventListener('mouseleave', () => this.hide());
+        }
     }
 
     disconnectedCallback() {
@@ -60,6 +70,11 @@ export class NxaElementHighlighter extends LitElement {
 
         window.removeEventListener('resize', () => this.requestUpdate());
         window.removeEventListener('scroll', () => this.requestUpdate());
+
+        if (this.showOnHover) {
+            this.targetElement.removeEventListener('mouseenter', () => this.show());
+            this.removeEventListener('mouseleave', () => this.hide());
+        }
 
         this.resizeObserver.disconnect();
         this.mutationObserver.disconnect();
@@ -113,5 +128,11 @@ export class NxaElementHighlighter extends LitElement {
         area.appendChild(slot);
 
         return area;
+    }
+
+    private validateInputs() {
+        if (this.initiallyShown && this.showOnHover) {
+            throw new Error('showOnHover and initiallyShown cannot be used together');
+        }
     }
 }


### PR DESCRIPTION
Hi @dermatthes,

wie besprochen, habe ich mich heute nochmal mit dem Projekt befasst.

Um dir heute ein erstes Ergebnis liefern zu können, habe ich mich doch erstmal mit der Highlight-Komponente befasst - die URL-Parameter-Features beim doc-visualizer haben auf den ersten Blick schon gut funktioniert und mit den komplexeren Punkten wie responsive Ansichten, Vorschau im iFrame, etc. würde ich mich dann lieber mal in Ruhe befassen!

Hier also ein erster Stand des Highlighters mit folgenden Features:
- `<slot>`s für Buttons inkl. Positionierung
- Anzeigen/Verstecken via `show()`/`hide()`-Methoden, `initiallyShown`- oder `showOnHover`-Attribut
- Konfigurierbare `borderColor` und `borderWidth`; weitere Style-Einstellungen (bspw. auch für die Buttons) habe ich jetzt erstmal weggelassen.
- Reagiert auf `window:resize`, `window:scroll` sowie auf `resize`-Events (`ResizeObserver`) und Style-Änderungen (`MutationObserver`) des Ziel-Elements (z.B. `margin` ändert die Positionierung)
  - ⚠️ `resize`-Events werden aktuell vom doc-visualizer abgefangen und triggern dort das erneute Rendern der Beispiele ([hier](https://github.com/nextrap/nextrap-doc-visualizer/blob/02d8c46f306a46a1184fb924c2628fb1727982f6/src/visualizer/nx-doc-visualizer.ts#L276)), daher scheint es aktuell so, dass der Highlighter nicht korrekt funktioniert im ersten Beispiel (weil es dann wieder initial versteckt ist). Beim zweiten Beispiel mit `initiallyShown` sieht es dann so aus, als würde es funktionieren. De facto rendert hier also immer der doc-visualizer neu und nicht das interne resize-Handling des Highlighters.

## Sonstiges
- Beim doc-visualizer scheine ich noch keine Schreibrechte zu haben. Habe dort Support für HTML in den Beschreibungen ergänzt, konnte aber nicht pushen. Daher siehst du jetzt noch `<p>...` etc.
- Was haltet ihr von der Verwendung von [prettier](https://github.com/prettier/prettier) in den Projekten? Ich bin es gewöhnt, dass ich mich um Format nicht mehr kümmern muss und gerade mit mehreren Leuten scheint mir das sehr sinnvoll.
- Aufgrund der Zeit habe ich mich jetzt auch erstmal nicht weiter mit dem webpack/kickstart/workspaces/... Setup befasst. Hat jetzt heute gut funktioniert die Arbeit in beiden Repos parallel 👍🏻

Lass uns dann gerne übernächste Woche wieder sprechen und ich gehe die anderen Punkte an.

Gruß
Enzo